### PR TITLE
Reboot adjustments

### DIFF
--- a/relops_hardware_controller/api/management/commands/ipmitool.py
+++ b/relops_hardware_controller/api/management/commands/ipmitool.py
@@ -94,7 +94,6 @@ class Command(BaseCommand):
 
         validate_host(options['address'])
         self.validate_privlvl(options['privlvl'])
-        # TODO: validate all the other args and command
 
         call_args = [
             'ipmitool',
@@ -107,15 +106,9 @@ class Command(BaseCommand):
             '-P', options['password'],
         ] + command
 
-        # Raises exceptions for failure, non-zero returncode, and timeouts
-        logger.debug('calling ipmitool with args: {}'.format(call_args))
+        logger.info(' '.join(call_args))
 
-        # for Python 3 decode to bytes to fix:
-        # TypeError: endswith first arg must be bytes or a tuple of bytes, not str
         output = subprocess.check_output(call_args,
                                          stderr=subprocess.STDOUT,
+                                         encoding='utf-8',
                                          timeout=options['timeout'])
-        if hasattr(output, 'decode'):
-            return output.decode()
-        else:
-            return output

--- a/relops_hardware_controller/api/management/commands/ping.py
+++ b/relops_hardware_controller/api/management/commands/ping.py
@@ -44,6 +44,7 @@ class Command(BaseCommand):
 
         call_args = [
             'ping',
+            '-q', # only print summary lines
             '-c', str(options['count']),
             '-w', str(options['timeout']),
             host,

--- a/relops_hardware_controller/api/management/commands/ping.py
+++ b/relops_hardware_controller/api/management/commands/ping.py
@@ -48,9 +48,11 @@ class Command(BaseCommand):
             '-c', str(options['count']),
             '-w', str(options['timeout']),
             host,
+            '|tail -2|tr \'\n\' \'\t\'',
         ]
 
-        return subprocess.check_output(call_args,
+        return subprocess.check_output(' '.join(call_args),
                                        stderr=subprocess.STDOUT,
                                        encoding='utf-8',
+                                       shell=True,
                                        timeout=(2 + options['timeout']))

--- a/relops_hardware_controller/api/management/commands/ping.py
+++ b/relops_hardware_controller/api/management/commands/ping.py
@@ -43,12 +43,12 @@ class Command(BaseCommand):
         validate_host(host)
 
         call_args = [
-            'ping',
+            'set -e;out=$(ping',
             '-q', # only print summary lines
             '-c', str(options['count']),
             '-w', str(options['timeout']),
             host,
-            '|tail -2|tr \'\n\' \'\t\'',
+            ');echo $out|tail -2|tr \'\n\' \'\t\'',
         ]
 
         return subprocess.check_output(' '.join(call_args),

--- a/relops_hardware_controller/api/management/commands/reboot.py
+++ b/relops_hardware_controller/api/management/commands/reboot.py
@@ -22,7 +22,7 @@ def can_ping(fqdn, count=4, timeout=5):
         logger.debug('pinging %s succeeded', fqdn)
         return True
     except Exception as error:
-        logger.info('pinging %s failed: %s', fqdn, error)
+        logger.warn('pinging %s failed: %s', fqdn, error)
         return False
 
 
@@ -87,6 +87,7 @@ class Command(BaseCommand):
         logger.debug('reboot_methods:{}'.format(settings.REBOOT_METHODS))
         stdout = StringIO()
         for reboot_method in settings.REBOOT_METHODS:
+            reboot_args = []
             logger.debug('reboot_method:{}'.format(reboot_method))
             try:
                 if reboot_method == 'ssh_reboot':
@@ -101,8 +102,7 @@ class Command(BaseCommand):
                     reboot_args = [ reboot_method ]
                     reboot_method = 'ipmi'
                 elif reboot_method == 'snmp_reboot':
-                    hostname, port_args = server['pdu'].rsplit(':', 1)
-                    reboot_args = list(port_args)
+                    reboot_args = server['pdu'].rsplit(':', 1)
                 elif reboot_method == 'xenapi_reboot':
                     reboot_args = server['xen']['reboot']
                 elif reboot_method == 'ilo_reboot':

--- a/relops_hardware_controller/api/management/commands/reboot.py
+++ b/relops_hardware_controller/api/management/commands/reboot.py
@@ -62,8 +62,7 @@ def reboot_succeeded(fqdn):
 
 
 class Command(BaseCommand):
-    help = '''Tries to reboot a machine using ssh, ipmi, snmp, xen, then ilo.
-    When all of those methods fail it files a bug in bugzilla.'''
+    help = '''Tries reboot actions from REBOOT_METHODS environment var.'''
 
     def add_arguments(self, parser):
         # Positional arguments

--- a/relops_hardware_controller/api/management/commands/reboot.py
+++ b/relops_hardware_controller/api/management/commands/reboot.py
@@ -121,7 +121,7 @@ class Command(BaseCommand):
                     break
             except Exception as error:
                 # try the next reboot method without waiting for the machine to come up
-                logger.info('reboot: %s of %s failed with error: %s', reboot_method, hostname, error)
+                logger.warn('reboot: %s of %s failed with error: %s', reboot_method, hostname, error)
                 continue
 
             # reboot method failed or didn't come up so try the next method

--- a/relops_hardware_controller/celery.py
+++ b/relops_hardware_controller/celery.py
@@ -13,6 +13,8 @@ import dns.resolver
 import dns.name
 
 from celery import Celery
+
+from django.conf import settings
 from django.core.management import (
     call_command,
     load_command_class,
@@ -108,7 +110,7 @@ def celery_call_command(job_data):
     try:
         client_id = job_data['client_id']
         username = re.search('^mozilla(-auth0/ad\|Mozilla-LDAP\||-ldap\/)([^ @]+)(@mozilla\.com)?$', client_id).group(2)
-        notify.email({**mail_payload, 'address': '{}@mozilla.com'.format(username)})
+        notify.email({**mail_payload, 'address': '{}@mozilla.com'.format(username))
     except Exception as e:
         logging.warn(e)
 

--- a/relops_hardware_controller/celery.py
+++ b/relops_hardware_controller/celery.py
@@ -76,12 +76,16 @@ def celery_call_command(job_data):
     try:
         call_command(cmd_class, hostname, command, stdout=stdout, stderr=stdout)
     except subprocess.TimeoutExpired as e:
-        logging.warn(e)
-        message = e.output
+        logging.exception(e)
+        message = 'timed out'
     except subprocess.CalledProcessError as e:
-        logging.warn(e)
+        logging.exception(e)
         message = e.output
+    except KeyError as e:
+        logging.exception(e)
+        message = 'Key error: {}'.format(e)
     except Exception as e:
+        logging.exception(e)
         message = e
     else:
         message = stdout.getvalue()
@@ -100,6 +104,7 @@ def celery_call_command(job_data):
             'address': '{}@mozilla.com'.format(username),
             'replyTo': 'relops@mozilla.com',
             'content': message,
+            'template': 'fullscreen',
             'link': { 'href':link, 'text':link[:text_link_max] },
         }
         notify.email(mail_payload)

--- a/relops_hardware_controller/celery.py
+++ b/relops_hardware_controller/celery.py
@@ -105,9 +105,9 @@ def celery_call_command(job_data):
         'link': { 'href':link, 'text':link[:text_link_max] },
     }
 
-    notify.email(mail_payload)
-
     try:
+        notify.email(mail_payload)
+        
         client_id = job_data['client_id']
         username = re.search('^mozilla(-auth0/ad\|Mozilla-LDAP\||-ldap\/)([^ @]+)(@mozilla\.com)?$', client_id).group(2)
         notify.email({**mail_payload, 'address': '{}@mozilla.com'.format(username)})

--- a/relops_hardware_controller/celery.py
+++ b/relops_hardware_controller/celery.py
@@ -108,7 +108,7 @@ def celery_call_command(job_data):
     try:
         client_id = job_data['client_id']
         username = re.search('^mozilla(-auth0/ad\|Mozilla-LDAP\||-ldap\/)([^ @]+)(@mozilla\.com)?$', client_id).group(2)
-        notify.email({**mail_payload, 'address': '{}@mozilla.com'.format(username))
+        notify.email({**mail_payload, 'address': '{}@mozilla.com'.format(username)})
     except Exception as e:
         logging.warn(e)
 

--- a/relops_hardware_controller/celery.py
+++ b/relops_hardware_controller/celery.py
@@ -117,6 +117,7 @@ def celery_call_command(job_data):
         irc_message_max = 510
         while message:
             chunk = message[:irc_message_max]
+            notify.irc({ 'channel': settings.NOTIFY_IRC_CHANNEL, 'message': chunk })
             notify.irc({ 'user': username, 'message': chunk })
             message = message[irc_message_max:]
     except Exception as e:

--- a/relops_hardware_controller/celery.py
+++ b/relops_hardware_controller/celery.py
@@ -110,7 +110,7 @@ def celery_call_command(job_data):
     try:
         client_id = job_data['client_id']
         username = re.search('^mozilla(-auth0/ad\|Mozilla-LDAP\||-ldap\/)([^ @]+)(@mozilla\.com)?$', client_id).group(2)
-        notify.email({**mail_payload, 'address': '{}@mozilla.com'.format(username))
+        notify.email({**mail_payload, 'address': '{}@mozilla.com'.format(username)})
     except Exception as e:
         logging.warn(e)
 

--- a/relops_hardware_controller/settings.py
+++ b/relops_hardware_controller/settings.py
@@ -187,7 +187,7 @@ class Base(Configuration, Celery):
         for task_name in TASK_NAMES.value
     ], seq_separator=',', environ_prefix=None)
 
-    VALID_WORKER_ID_REGEX = values.Value('^t-linux64-ms.*', environ_prefix=None)
+    VALID_WORKER_ID_REGEX = values.Value('^.*', environ_prefix=None)
 
     # Worker Settings
 

--- a/relops_hardware_controller/settings.py
+++ b/relops_hardware_controller/settings.py
@@ -191,6 +191,9 @@ class Base(Configuration, Celery):
 
     # Worker Settings
 
+    NOTIFY_EMAIL = values.Value('dhouse@mozilla.com', environ_prefix=None)
+    NOTIFY_IRC_CHANNEL = values.Value('#roller', environ_prefix=None)
+
     BUGZILLA_URL = values.URLValue(environ_prefix=None)
     BUGZILLA_API_KEY = values.SecretValue(environ_prefix=None)
 


### PR DESCRIPTION
* more logging for action exceptions
    * specific result message for time-out of action and key-errors
* email a default/group all results
* send all results to an irc channel
* use the larger email template
* update snmp_reboot to use snmpset command matching slaveapi1 (including community string)