### PR TITLE
allow ipmi failure and rely on ping

### DIFF
--- a/relops_hardware_controller/api/management/commands/ipmitool.py
+++ b/relops_hardware_controller/api/management/commands/ipmitool.py
@@ -79,7 +79,7 @@ class Command(BaseCommand):
         parser.add_argument(
             '--timeout',
             dest='timeout',
-            default=5,
+            default=15,
             type=int,
             help='stop after N seconds',
         )
@@ -108,7 +108,12 @@ class Command(BaseCommand):
 
         logger.info(' '.join(call_args))
 
-        output = subprocess.check_output(call_args,
-                                         stderr=subprocess.STDOUT,
-                                         encoding='utf-8',
-                                         timeout=options['timeout'])
+        try:
+            return subprocess.check_output(call_args,
+                                           stderr=subprocess.STDOUT,
+                                           encoding='utf-8',
+                                           timeout=options['timeout'])
+        except Exception as e:
+            logging.exception(e)
+            logging.warn('ipmitool may report failure on success. '
+                         'So we ignore the exception and check for ping:')


### PR DESCRIPTION
@dividehex @dragoscrisan 
In https://bugzilla.mozilla.org/show_bug.cgi?id=1469144 ipmitool sometimes, and lately for the moonshots, takes a long time (more than 5s) and reports a failure despite action success.
To workaround this, we can increase the timeout (15s) for the call and allow ipmitool failures. The reboot check pings the machine and will either timeout on is_down and then continue to try a different reboot method, or it will find that the machine shuts down (changes into no ping response) and then comes back up (changes into ping response state).