### PR TITLE
Bug1457003 ssh reboots

### DIFF
--- a/relops_hardware_controller/api/management/commands/reboot.py
+++ b/relops_hardware_controller/api/management/commands/reboot.py
@@ -92,10 +92,16 @@ class Command(BaseCommand):
             check = reboot_succeeded
             try:
                 if reboot_method == 'ssh_reboot':
-                    reboot_args = [
-                        '-l', server['ssh']['user'],
-                        '-i', server['ssh']['key_file'],
-                    ]
+                    try:
+                        reboot_args = [
+                            '-l', server['ssh']['user'],
+                            '-i', server['ssh']['key_file'],
+                        ]
+                    except KeyError:
+                        reboot_args = [
+                            '-l', 'roller',
+                            '-i', 'ssh.key',
+                        ]
                 elif reboot_method == 'ipmi_reset':
                     reboot_args = [ reboot_method ]
                     reboot_method = 'ipmi'

--- a/relops_hardware_controller/settings.py
+++ b/relops_hardware_controller/settings.py
@@ -231,11 +231,10 @@ class Base(Configuration, Celery):
     UP_TIMEOUT = values.IntegerValue(300, environ_prefix=None)
 
     REBOOT_METHODS = values.ListValue([
+        'ssh_reboot',
         'ipmi_reset',
         'ipmi_cycle',
         'snmp_reboot',  # snmp pdu for mac minis
-        # 'ilo_reboot',  # for moonshot HW
-        # 'ssh_reboot',
         'file_bugzilla_bug',  # give up and file a bug
     ], environ_prefix=None)
 


### PR DESCRIPTION
@dividehex @dragoscrisan @g-k 

1. "turn on" ssh reboots and make it the first method to attempt
2. default to user "roller" and "./ssh.key" key file if not set in config for a worker