### PR TITLE
add alias/DC to reboot template filling

### DIFF
--- a/relops_hardware_controller/api/management/commands/file_bugzilla_bug.py
+++ b/relops_hardware_controller/api/management/commands/file_bugzilla_bug.py
@@ -90,6 +90,8 @@ class Command(BaseCommand):
         # Get (if not closed) or create reboot bug.
         payload = reboot_template.safe_substitute(
             hostname=host,
+            alias=short_hostname,
+            DC=datacenter,
             blocks=parent,
             **job_data,
             **options,

--- a/relops_hardware_controller/api/management/commands/reboot.py
+++ b/relops_hardware_controller/api/management/commands/reboot.py
@@ -135,7 +135,7 @@ class Command(BaseCommand):
                 elif reboot_method == 'ilo_reboot':
                     hostname, reboot_args = server['ilo']
                 elif reboot_method == 'file_bugzilla_bug':
-                    result_template = 'failed. bug {stdout}'
+                    result_template = 'failed. {stdout}'
                     reboot_args = [
                         json.dumps(job_data),
                         '--log', reboot_attempt_log,

--- a/relops_hardware_controller/api/management/commands/reboot.py
+++ b/relops_hardware_controller/api/management/commands/reboot.py
@@ -90,6 +90,11 @@ class Command(BaseCommand):
 
         logger.debug('reboot_methods:{}'.format(settings.REBOOT_METHODS))
         stdout = StringIO()
+        try:
+            bug_cc_email = server['bug_cc']
+        except Exception as e:
+            logging.warn(e)
+            bug_cc_email = ''
         for reboot_method in settings.REBOOT_METHODS:
             reboot_args = []
             logger.debug('reboot_method:{}'.format(reboot_method))
@@ -138,6 +143,7 @@ class Command(BaseCommand):
                     result_template = 'failed. {stdout}'
                     reboot_args = [
                         json.dumps(job_data),
+                        '--cc', bug_cc_email,
                         '--log', reboot_attempt_log,
                     ]
                     def check(hostname):

--- a/relops_hardware_controller/api/management/commands/snmp_reboot.py
+++ b/relops_hardware_controller/api/management/commands/snmp_reboot.py
@@ -114,10 +114,11 @@ class Command(BaseCommand):
         self.tower, self.infeed, self.outlet = self._parse_port(port)
 
         logger.info("Powercycling {} via {}.".format(fqdn, pdu))
+        output += "SNMP to {}:".format(pdu))
 
         if options['delay'] > 0:
             logger.info('Powering down {} ...'.format(fqdn))
-            output = self.run_cmd(pdu, self.cmds['off'], **options)
+            output += self.run_cmd(pdu, self.cmds['off'], **options)
 
             delay_note = ' wait {}s ... '.format(options['delay'])
             logger.info(delay_note)
@@ -127,6 +128,6 @@ class Command(BaseCommand):
             logger.info('Powering up {} ...'.format(fqdn))
             output += self.run_cmd(pdu, self.cmds['on'], **options)
         else:
-            output = self.run_cmd(pdu, self.cmds['reboot'], **options)
+            output += self.run_cmd(pdu, self.cmds['reboot'], **options)
 
         return output

--- a/relops_hardware_controller/api/management/commands/snmp_reboot.py
+++ b/relops_hardware_controller/api/management/commands/snmp_reboot.py
@@ -114,7 +114,7 @@ class Command(BaseCommand):
         self.tower, self.infeed, self.outlet = self._parse_port(port)
 
         logger.info("Powercycling {} via {}.".format(fqdn, pdu))
-        output += "SNMP to {}:".format(pdu))
+        output += "SNMP to {}:".format(pdu)
 
         if options['delay'] > 0:
             logger.info('Powering down {} ...'.format(fqdn))

--- a/relops_hardware_controller/celery.py
+++ b/relops_hardware_controller/celery.py
@@ -135,12 +135,6 @@ def celery_call_command(job_data):
         logging.warn(e)
 
     try:
-        cc_email = settings.NOTIFY_EMAIL_CC
-        notify.email({**mail_payload, 'address': cc_email})
-    except:
-        pass
-
-    try:
         message = '{}: {}'.format(subject, message.replace('\r', '\t'))
         irc_message_max = 510
         while message:

--- a/relops_hardware_controller/celery.py
+++ b/relops_hardware_controller/celery.py
@@ -135,7 +135,7 @@ def celery_call_command(job_data):
         logging.warn(e)
 
     try:
-        message = '{}: {}'.format(subject, message)
+        message = '{}: {}'.format(subject, message.replace('\r', '\t'))
         irc_message_max = 510
         while message:
             chunk = message[:irc_message_max]

--- a/relops_hardware_controller/celery.py
+++ b/relops_hardware_controller/celery.py
@@ -135,6 +135,12 @@ def celery_call_command(job_data):
         logging.warn(e)
 
     try:
+        cc_email = settings.NOTIFY_EMAIL_CC
+        notify.email({**mail_payload, 'address': cc_email})
+    except:
+        pass
+
+    try:
         message = '{}: {}'.format(subject, message.replace('\r', '\t'))
         irc_message_max = 510
         while message:

--- a/relops_hardware_controller/settings.py
+++ b/relops_hardware_controller/settings.py
@@ -188,7 +188,8 @@ class Base(Configuration, Celery):
 
     # Worker Settings
 
-    NOTIFY_EMAIL = values.Value('dhouse@mozilla.com', environ_prefix=None)
+    NOTIFY_EMAIL = values.Value('', environ_prefix=None)
+    NOTIFY_EMAIL_CC = values.Value('', environ_prefix=None)
     NOTIFY_IRC_CHANNEL = values.Value('#roller', environ_prefix=None)
 
     BUGZILLA_URL = values.URLValue('https://bugzilla.mozilla.org', environ_prefix=None)

--- a/relops_hardware_controller/settings.py
+++ b/relops_hardware_controller/settings.py
@@ -189,7 +189,6 @@ class Base(Configuration, Celery):
     # Worker Settings
 
     NOTIFY_EMAIL = values.Value('', environ_prefix=None)
-    NOTIFY_EMAIL_CC = values.Value('', environ_prefix=None)
     NOTIFY_IRC_CHANNEL = values.Value('#roller', environ_prefix=None)
 
     BUGZILLA_URL = values.URLValue('https://bugzilla.mozilla.org', environ_prefix=None)


### PR DESCRIPTION
Switching reboot/unavailable bugs from DCOps to RelOps component in puppet -- add DC and host alias to the bug template filling. A few other cleanup changes: 
* Replace newlines with tabs for IRC posts so lines have space between them.
* Include the SNMP pdu address in the notification for a failed snmp reboot.