### PR TITLE
catch and report SoftTimeLimitExceeded

### DIFF
--- a/relops_hardware_controller/api/management/commands/ipmitool.py
+++ b/relops_hardware_controller/api/management/commands/ipmitool.py
@@ -1,9 +1,10 @@
-
 import logging
 import subprocess
 
 from django.core.exceptions import ValidationError
 from django.core.management.base import BaseCommand
+
+from celery.exceptions import SoftTimeLimitExceeded
 
 from relops_hardware_controller.api.validators import validate_host
 
@@ -111,6 +112,8 @@ class Command(BaseCommand):
                                            stderr=subprocess.STDOUT,
                                            encoding='utf-8',
                                            timeout=options['timeout'])
+        except SoftTimeLimitExceeded as e:
+            raise e
         except Exception as e:
             logging.warn('ipmitool may report failure on success. '
                          'So we ignore the exception and check for ping:')

--- a/relops_hardware_controller/api/management/commands/ssh_reboot.py
+++ b/relops_hardware_controller/api/management/commands/ssh_reboot.py
@@ -1,4 +1,3 @@
-
 import logging
 import subprocess
 
@@ -88,7 +87,8 @@ class Command(BaseCommand):
             try:
                 return subprocess.check_output(call_args + [reboot_cmd],
                                                stderr=subprocess.STDOUT,
-                                               timeout=options['timeout']).decode()
+                                               encoding='utf-8',
+                                               timeout=options['timeout'])
             except subprocess.CalledProcessError as error:
                 logger.info('{} ssh reboot with command {} failed: {}'.format(hostname, reboot_cmd, error))
 

--- a/relops_hardware_controller/celery.py
+++ b/relops_hardware_controller/celery.py
@@ -96,20 +96,18 @@ def celery_call_command(job_data):
             logging.warn(e)
 
     stdout = StringIO()
+    message = ''
     try:
         call_command(cmd_class, hostname, json.dumps(job_data), stdout=stdout, stderr=stdout)
-    except subprocess.TimeoutExpired as e:
-        logging.exception(e)
-        message = 'timed out'
-    except subprocess.CalledProcessError as e:
-        logging.exception(e)
-        message = e.output
     except KeyError as e:
         logging.exception(e)
         message = 'Key error: {}'.format(e)
     except Exception as e:
         logging.exception(e)
-        message = e
+        try:
+            message = e.output
+        except:
+            message = e
     else:
         message = stdout.getvalue()
         logging.info(message)


### PR DESCRIPTION
For the pings and ipmitool calls, it was ignoring the timeout exceptions. This catches those timeouts and raises them up to celery to report through taskcluster.notify to irc/email.