### PR TITLE
upgrade django rest framework to 3.9.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ django-configurations==2.1
 django-filter==2.0.0
 django-celery-results==1.0.1
 django-redis==4.9.0
-djangorestframework==3.7.3
+djangorestframework==3.9.4
 dnspython==1.15.0
 gunicorn==19.9.0
 Markdown==3.0.1


### PR DESCRIPTION
Bump DRF to 3.9.4

At quick glance I didn't see anything breaking in the changelog, but I didn't run tests https://github.com/encode/django-rest-framework/blob/master/docs/community/release-notes.md 


r? @davehouse 